### PR TITLE
Standard errors for power estimate, and speed improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@ Longitudinal MRI Calculator for power analyses
 
 # Depends on...
 
-library("lme4")
-library("GGally")
-library("knitr")
-library("tidyverse")
-library("simstudy")
-library("arm")
-library("shinythemes")
-library("shinyjs")
-library("stringr")
+- install.packages("lme4")
+- install.packages("GGally")
+- install.packages("knitr")
+- install.packages("tidyverse")
+- install.packages("simstudy")
+- install.packages("arm")
+- install.packages("shinythemes")
+- install.packages("shinyjs")
+- install.packages("stringr")
+
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # longmri_shiny
 Longitudinal MRI Calculator for power analyses
+
+# Depends on...
+
+library("lme4")
+library("GGally")
+library("knitr")
+library("tidyverse")
+library("simstudy")
+library("arm")
+library("shinythemes")
+library("shinyjs")
+library("stringr")
+

--- a/app.R
+++ b/app.R
@@ -150,6 +150,16 @@ ui <- fluidPage(theme = shinytheme("superhero"),
                     selectInput("graph", "Would you like create a graph? Warning: Depending on your parameters (e.g., high N, high simulation), this option could take a while.",
                                 c("No",
                                   "Yes")),
+                    # Input: If they did want to create a graph, input min sample size 
+                    conditionalPanel(
+                      condition = "input.graph == 'Yes'",
+                      numericInput("min.sample.size", "Minimum sample size: ", 10)
+                    ),
+                    # Input: If they did want to create a graph, input step size 
+                    conditionalPanel(
+                      condition = "input.graph == 'Yes'",
+                      numericInput("sample.step.size", "For each simulation, increase sample by: ", 20)
+                    ),
                     # Input: Lets user select if they would like to customize parameters
                     selectInput("CUSTOM", "Would you like to set custom parameters for the Intercept and Variance?",
                                 c("No",
@@ -204,8 +214,8 @@ server <- function(input, output) {
       return(list(power = power, lower = ci_power[1], upper = ci_power[2]))
     }
   }
-  graph.power<-function(N,DIST,DELTA,CUSTOM,INTERCEPT,VARIANCE,n.sims){
-    KK<-seq(10, N, by=5)       #will ieterate from 3 cases to the max.K specified in the function above
+  graph.power<-function(N,DIST,DELTA,CUSTOM,INTERCEPT,VARIANCE,n.sims,min.N=10,step.N=20){
+    KK<-seq(min.N, N, by=step.N)       #will ieterate from 3 cases to the max.K specified in the function above
     Y<-rep(NA, length(KK))        #Empty vector to contain power estimates from mixed.power () function
     upper<-rep(NA, length(KK))
     lower<-rep(NA, length(KK))
@@ -263,7 +273,9 @@ observeEvent(input$calculate,{
                           CUSTOM=input$CUSTOM,
                           INTERCEPT= input$INTERCEPT,
                           VARIANCE= input$VARIANCE,
-                          n.sims=input$n.sims))
+                          n.sims=input$n.sims,
+                          min.N=input$min.sample.size,
+                          step.N=input$sample.step.size))
         },height = 400, width = 600)
       })
     }

--- a/app.R
+++ b/app.R
@@ -199,8 +199,8 @@ server <- function(input, output) {
         }
         lme.power.null<-lmer(brain.measure~1+(1|ID), REML = FALSE,data=fake.data)
         lme.power<-lmer(brain.measure~Age+(1|ID), REML = FALSE,data=fake.data)            #estimates mixed effect model using each simulated dataset
-        theta.hat<-fixef(lme.power)["Age"]                                  #saves age coefficients from each simulated dataset 
-        theta.se<-se.fixef(lme.power)["Age"]                                #saves standard error of age coefficients from each simulated dataset
+        # theta.hat<-fixef(lme.power)["Age"]                                  #saves age coefficients from each simulated dataset 
+        # theta.se<-se.fixef(lme.power)["Age"]                                #saves standard error of age coefficients from each simulated dataset
         signif[s]<-ifelse(anova(lme.power.null,lme.power)$`Pr(>Chisq)`[2]<.05, 1, 0)#assigns value of 1 to significant coefficients 0 to ns coefficients
         incProgress(1/n.sims, detail = paste("Simulation", s))
       }
@@ -215,7 +215,7 @@ server <- function(input, output) {
     }
   }
   graph.power<-function(N,DIST,DELTA,CUSTOM,INTERCEPT,VARIANCE,n.sims,min.N=10,step.N=20){
-    KK<-seq(min.N, N, by=step.N)       #will ieterate from 3 cases to the max.K specified in the function above
+    KK<-seq(min.N, N, by=step.N)       #will ieterate from min.N cases to the max.K specified in the function above
     Y<-rep(NA, length(KK))        #Empty vector to contain power estimates from mixed.power () function
     upper<-rep(NA, length(KK))
     lower<-rep(NA, length(KK))


### PR DESCRIPTION
First, I added confidence intervals around the power estimate using the formula for the standard error of proportions (`sqrt( p * (1-p) / n )`), and add that info to the graph as well using `geom_errorbar` at each point estimate.

Second, I tried to increase the speed of the algorithm by generating all fake data at once, and taking a subset for each simulation (so, for 10 sims of N=100, making fake data for 10*100 IDs and then subsetting by each 100 IDs). This offers a substantial speed improvement. I also translated some code into the equivalent data.table syntax, which boosts speed by a little bit. This should help make the graph generation a bit easier on folks.